### PR TITLE
Reapply typo fix

### DIFF
--- a/epoch.el
+++ b/epoch.el
@@ -49,7 +49,7 @@ Argument ADVISED is `current-time'."
   (funcall float-time epoch-current-time))
 
 (defun epoch-advice-enabled-p ()
-  "Return t if `epoch-current-time-advie' enabled, nil otherwise."
+  "Return t if `epoch-current-time-advice' enabled, nil otherwise."
   (and (advice-member-p #'epoch-current-time-advice 'current-time) t))
 
 (defun epoch-advice (&optional arg)


### PR DESCRIPTION
#2 was merged and then regressed (probably with an accidental force push), so here it is again.