### PR TITLE
Don't supply a default-input string to org-read-date

### DIFF
--- a/epoch.el
+++ b/epoch.el
@@ -116,11 +116,9 @@ Optional argument ARG is passed to `org-todo'."
   (interactive "P")
   ;;@Incomplete:
   ;;if Effort prop, add that to hours and use that string
-  (let* ((timestamp (epoch--timestamp-time))
-         (default-string
-           (format-time-string "%Y-%m-%d %H:%M" timestamp)))
+  (let* ((timestamp (epoch--timestamp-time)))
     (epoch-with-time (org-read-date 'with-time 'to-time nil "Epoch todo @: "
-                                    timestamp default-string)
+                                    timestamp)
       (when org-log-repeat (setq epoch-last-time epoch-current-time)
             (advice-add 'org-entry-put :around 'epoch--last-repeat))
       (org-todo arg))))


### PR DESCRIPTION
This `default-input` string prevents `org-read-date` from changing the date via interactive keyboard shortcuts such as `Shift-<left>`, `Shift-<right>` etc. because whatever timestamp data is present after the user prompt will override any date selected in the `Calendar` buffer.

Fixes #5.